### PR TITLE
fix: FactoCord can get stuck waiting for Factorio to stop

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ func main() {
 	}
 	if support.Factorio.IsRunning() {
 		fmt.Println("Waiting for factorio server to exit...")
+		support.Factorio.Send("/quit")
 		err := support.Factorio.Process.Wait()
 		if support.Factorio.Process.ProcessState.Exited() {
 			fmt.Println("\nFactorio server was closed, exit code", support.Factorio.Process.ProcessState.ExitCode())


### PR DESCRIPTION
Simply triggering /quit again will resolve certain cases where FactoCord is waiting on Factorio to stop but Factorio has not been told to stop.