### PR TITLE
Modified control.lua to show the reason a player died in discord.

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -7,7 +7,7 @@
 local FactoCordIntegration = {}
 
 function FactoCordIntegration.PrintToDiscord(msg)
-	print("0000-00-00 00:00:00 [DISCORD] "..msg)
+	print({"", "0000-00-00 00:00:00 [DISCORD] ", msg})
 end
 
 script.on_event(defines.events.on_player_joined_game, function(event)
@@ -49,7 +49,12 @@ script.on_event({defines.events.on_console_chat},
 
 script.on_event(defines.events.on_player_died, function(event)
 	local p = game.players[event.player_index];
-	FactoCordIntegration.PrintToDiscord("**" .. p.name .. "** died.");
+	local c = event.cause
+	if not c then
+		FactoCordIntegration.PrintToDiscord("**" .. p.name .. "** died.");
+	else
+		FactoCordIntegration.PrintToDiscord({"", "**" .. p.name .. "** died to a " , c.localised_name, "."});
+	end
 end)
 script.on_event(defines.events.on_player_kicked, function(event)
 	local p = game.players[event.player_index];

--- a/control.lua
+++ b/control.lua
@@ -2,7 +2,7 @@
  -- Please configure as needed, any discord message will be sent in
  --  raw format if it starts with `0000-00-00 00:00:00 [DISCORD] `
  -- For more information visit https://github.com/maxsupermanhd/FactoCord-3.0
- -- If you have any question or comments join our Discord https://discord.gg/SUJRG47
+ -- If you have any question or comments join our Discord https://discord.gg/uNhtRH8
 
 local FactoCordIntegration = {}
 
@@ -55,7 +55,7 @@ script.on_event(defines.events.on_player_died, function(event)
 	else
 		local name = "Unknown";
 		if c.type == "character" then
-			name = {"", "player", " ", c.player.name};
+			name = c.player.name;
 		elseif c.type == "spider-vehicle" then
 			if c.entity_label then
 				name = {"", c.localised_name, " " , c.entity_label};

--- a/control.lua
+++ b/control.lua
@@ -7,7 +7,7 @@
 local FactoCordIntegration = {}
 
 function FactoCordIntegration.PrintToDiscord(msg)
-	print({"", "0000-00-00 00:00:00 [DISCORD] ", msg})
+	localised_print({"", "0000-00-00 00:00:00 [DISCORD] ", msg})
 end
 
 script.on_event(defines.events.on_player_joined_game, function(event)

--- a/control.lua
+++ b/control.lua
@@ -53,7 +53,21 @@ script.on_event(defines.events.on_player_died, function(event)
 	if not c then
 		FactoCordIntegration.PrintToDiscord("**" .. p.name .. "** died.");
 	else
-		FactoCordIntegration.PrintToDiscord({"", "**" .. p.name .. "** died to a " , c.localised_name, "."});
+		local name = "Unknown";
+		if c.type == "character" then
+			name = {"", "player", " ", c.player.name};
+		elseif c.type == "spider-vehicle" then
+			if c.entity_label then
+				name = {"", c.localised_name, " " , c.entity_label};
+			else
+				name = {"", "a ", c.localised_name};
+			end
+		elseif c.type == "locomotive" then
+			name = {"", c.localised_name, " " , c.backer_name};
+		else
+			name = {"", "a ", c.localised_name};
+		end
+		FactoCordIntegration.PrintToDiscord({"", "**", p.name, "** was killed by ", name, "."});
 	end
 end)
 script.on_event(defines.events.on_player_kicked, function(event)


### PR DESCRIPTION
The topic came up a few hours on the discord of the Factorio server I play on to have death messages included in the reason a person died. So I poked around and modified the control.lua file included with FactoCord to do so. Everything functions without errors in SP and a client-hosted server but since I haven't tested with FactoCord+headless I can't be positive it works as intended.

Now death messages sent to discord will be `0000-00-00 00:00:00 [DISCORD] **credomane** died to a Small biter.` when possible instead of always being `0000-00-00 00:00:00 [DISCORD] **credomane** has died.`