### PR TITLE
Propper startup message in discord

### DIFF
--- a/config-example.json
+++ b/config-example.json
@@ -58,7 +58,8 @@
 
     // messages for certain events.  set "" to hide that message
     messages: {
-        bot_start: "**:white_check_mark: Bot started! Launching server...**",
+        bot_start_launch: "**:white_check_mark: Bot started! Launching server...**",
+        bot_start_only: "**:white_check_mark: Bot started! Autolaunch disabled.**",
         bot_stop: ":v:",
         server_start: "**:white_check_mark: The server has started!**",
         server_stop: "**:octagonal_sign: The server has stopped!**",

--- a/config-example.json5
+++ b/config-example.json5
@@ -58,7 +58,8 @@
 
     // messages for certain events.  set "" to hide that message
     messages: {
-        bot_start: "**:white_check_mark: Bot started! Launching server...**",
+        bot_start_launch: "**:white_check_mark: Bot started! Launching server...**",
+        bot_start_only: "**:white_check_mark: Bot started! Autolaunch disabled.**",
         bot_stop: ":v:",
         server_start: "**:white_check_mark: The server has started!**",
         server_stop: "**:octagonal_sign: The server has stopped!**",

--- a/discord/chat.go
+++ b/discord/chat.go
@@ -53,7 +53,12 @@ func Init() {
 	support.Panik(err, "... when updating bot status")
 
 	fmt.Println("Bot is now running.  Press CTRL-C to exit.")
-	support.SendMessage(Session, support.Config.Messages.BotStart)
+	if Config.Autolaunch {
+		support.SendMessage(Session, support.Config.Messages.BotStartLaunch)
+	} else {
+		support.SendMessage(Session, support.Config.Messages.BotStartOnly)
+	}
+
 }
 
 func Close() {

--- a/support/config.go
+++ b/support/config.go
@@ -41,7 +41,8 @@ type configT struct {
 	ModPortalToken  string `json:"mod_portal_token"`
 
 	Messages struct {
-		BotStart          string `json:"bot_start"`
+		BotStartLaunch    string `json:"bot_start_launch"`
+		BotStartOnly      string `json:"bot_start_only"`
 		BotStop           string `json:"bot_stop"`
 		ServerStart       string `json:"server_start"`
 		ServerStop        string `json:"server_stop"`
@@ -100,7 +101,8 @@ func (conf *configT) defaults() {
 	conf.Prefix = "$"
 	// conf.HaveServerEssentials = false
 	// conf.IngameDiscordUserColors = false
-	conf.Messages.BotStart = "**:white_check_mark: Bot started! Launching server...**"
+	conf.Messages.BotStartLaunch = "**:white_check_mark: Bot started! Launching server...**"
+	conf.Messages.BotStartOnly = "**:white_check_mark: Bot started! Autolaunch disabled.**"
 	conf.Messages.BotStop = ":v:"
 	conf.Messages.ServerStart = "**:white_check_mark: The server has started!**"
 	conf.Messages.ServerStop = "**:octagonal_sign: The server has stopped!**"


### PR DESCRIPTION
At Bot startup the message in discord will either read `Bot started! Launching server...` or `Bot started! Autolaunch disabled.`, depending on autolaunch variable set in config.json 